### PR TITLE
docs(readme): fix plugin description for Marketplace validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # EduPy-Debugger
 
 <!-- Plugin description -->
+EduPy-Debugger is a lightweight, web-based debugging companion for Python in PyCharm. It offers visual object inspection, UML-style diagrams, and an integrated console in a clean tool window.
+
 EduPy‑Debugger ist ein schlankes, webbasiertes Debug‑Werkzeug für Python in PyCharm (Community & Professional) – mit klarem Fokus auf Unterricht und Einstieg. Es kombiniert eine aufgeräumte Debug‑Ansicht mit visualisierten Objekten und einer integrierten Konsole.
 
 Kurzüberblick:


### PR DESCRIPTION
Ensure the plugin description (used for Marketplace) starts with ASCII Latin characters and has >= 40 characters, to satisfy the descriptor validation. The German description remains right after the English intro.

Changes
- README.md: add a concise English first sentence between the plugin description markers; keep the German text below.

No code changes; build/test unaffected.