### PR TITLE
ci(release-please): add manual dispatch with `release-as` input

### DIFF
--- a/.github/workflows/release-please-manual.yml
+++ b/.github/workflows/release-please-manual.yml
@@ -1,0 +1,77 @@
+name: release-please-manual
+on:
+  workflow_dispatch:
+    inputs:
+      release-as:
+        description: 'Force release version (e.g., 1.0.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name:        ${{ steps.rp.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: rp
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          release-as: ${{ inputs.release-as }}
+
+  publish:
+    needs: release
+    if: ${{ needs.release.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Fetch Sources at release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag_name }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Extract version (strip leading 'v')
+        id: v
+        shell: bash
+        run: |
+          RAW="${{ needs.release.outputs.tag_name }}"
+          VERSION="${RAW#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Publish Plugin to Marketplace
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+        run: |
+          ./gradlew \
+            -PpluginVersion="${{ steps.v.outputs.version }}" \
+            publishPlugin --no-daemon --stacktrace
+
+      - name: Upload Release Asset (zip)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ needs.release.outputs.tag_name }}" ./build/distributions/*


### PR DESCRIPTION
Add a manual Release Please entry point that accepts a `release-as` input, so we can force a release version when there are no user‑facing commits (e.g., after squash merges or chore/docs‑only changes).

How to use
- Actions → release-please-manual → Run workflow → set `release-as` (e.g., 1.0.1). This opens/updates the automated release PR accordingly. Merge that PR to create the tag and trigger the publish job.

Notes
- This does not change the existing push‑to‑main automation.
- It uses the same publish stage as the regular workflow.
