### PR TITLE
chore(release-please): switch to java strategy + add gradle.properties markers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,9 @@ pluginGroup = de.code14.edupydebugger
 pluginName = EduPy-Debugger
 pluginRepositoryUrl = https://github.com/Julian-Code14/EduPy-Debugger
 # SemVer format -> https://semver.org
+# x-release-please-start-version
 pluginVersion = 1.0.0
+# x-release-please-end
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,15 +1,18 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "packages": {
     ".": {
-      "release-type": "simple",
+      "release-type": "java",
       "package-name": "edupy-debugger",
       "include-component-in-tag": false,
       "extra-files": [
-        "gradle.properties"
+        {
+          "type": "generic",
+          "path": "gradle.properties",
+          "regex": "(?s)(# x-release-please-start-version\n)pluginVersion = (?<version>[^\n]+)(\n# x-release-please-end)"
+        }
       ]
     }
   }


### PR DESCRIPTION
Switch release-please to the `java` strategy and add version markers in `gradle.properties` so that, after merging the release PR, an automatic Snapshot PR is opened again.

Changes
- release-please-config.json: `release-type: java` for the root package; `extra-files` uses a generic regex targeting the marked block in `gradle.properties`.
- gradle.properties: wrap `pluginVersion = …` with the standard markers
  - `# x-release-please-start-version`
  - `# x-release-please-end`

Notes
- No functional code changes.
- Please merge this before merging the 1.0.1 release PR, so the subsequent run creates the SNAPSHOT PR automatically.
