### PR TITLE
chore(version): set 1.0.5-SNAPSHOT on main

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = de.code14.edupydebugger
 pluginName = EduPy-Debugger
 pluginRepositoryUrl = https://github.com/Julian-Code14/EduPy-Debugger
 # x-release-please-start-version
-version = 1.0.4
+version = 1.0.5-SNAPSHOT
 # x-release-please-end
 
 # SemVer format -> https://semver.org


### PR DESCRIPTION
This PR restores the missing post-release snapshot bump.

- Sets `version` in `gradle.properties` to `1.0.5-SNAPSHOT` within the existing x-release-please markers.
- No source changes; build only reads the `version` property.
- Purpose: re-sync Release Please so subsequent releases and snapshot bumps proceed normally.

Validation
- No code changes; CI will run defaults. Local checks not required for a version-only update.

Follow-ups
- After merge, sync `main → dev` so development continues on `1.0.5-SNAPSHOT`.
