### PR TITLE
ci(release-please): skip labeling to avoid API error

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: main
           release-as: ${{ inputs.release_as }}
+          skip-labeling: true
   publish:
     needs: release
     if: ${{ needs.release.outputs.release_created == 'true' }}


### PR DESCRIPTION
Skip labeling to work around a GitHub label API error seen when forcing a release with `release_as`.

Context
- Recent `release-please` run failed adding labels with: Could not resolve to a node with the global id ...
- Labels are only cosmetic for our flow; skipping them avoids the failure and keeps Release PR + auto SNAPSHOT PR behavior intact.

Change
- `.github/workflows/release-please.yml`: add `skip-labeling: true` to the release-please action step.

Resulting flow
1) Merge this PR to `dev`, then merge `dev` → `main` to deploy the workflow update to `main`.
2) From Actions, run `release-please` with `release_as: 1.0.5` (no `-SNAPSHOT`).
3) Merge Release PR → tag + GitHub Release. Java strategy then opens the SNAPSHOT bump PR on `main` (e.g., `1.0.6-SNAPSHOT`).
4) Merge SNAPSHOT PR and sync `main` → `dev`.

Notes
- No effect on changelog/versioning behavior; only labels are skipped.
