### PR TITLE
ci(release-please): skip labeling + optional skip_pr; chore(release-please): strict regex for gradle.properties

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,11 @@ on:
         description: 'Force release as version (optional)'
         required: false
         type: string
+      skip_pr:
+        description: 'Skip creating a Release PR (tag/release directly)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -28,6 +33,7 @@ jobs:
           target-branch: main
           release-as: ${{ inputs.release_as }}
           skip-labeling: true
+          skip-github-pull-request: ${{ inputs.skip_pr }}
   publish:
     needs: release
     if: ${{ needs.release.outputs.release_created == 'true' }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,8 @@
       "extra-files": [
         {
           "type": "generic",
-          "path": "gradle.properties"
+          "path": "gradle.properties",
+          "regex": "(?s)(# x-release-please-start-version\\n)version = (?<version>[^\\n]+)(\\n# x-release-please-end)"
         }
       ]
     }


### PR DESCRIPTION
Hardening release-please so the flow is stable even after previous manual merges:

- Add `skip-labeling: true` to avoid the GitHub label API error (cosmetic only).
- Add `skip_pr` boolean input wiring `skip-github-pull-request` so we can force a tag/release (one-off recovery) if a stale release-please branch existed.
- Pin a strict `regex` for the Generic updater against the x-release-please markers in `gradle.properties`.

Effect
- Release PRs will contain the correct stable version (e.g. 1.0.5) and update `gradle.properties` reliably.
- After merging a Release PR or forcing a release, the Java strategy will open the `autorelease: snapshot` PR to bump to the next `-SNAPSHOT`.
- Labels are skipped; flow remains unchanged otherwise.

Next steps after merge
1) Merge this PR into `dev`.
2) Merge `dev` → `main`.
3) Run Actions → release-please with `release_as: 1.0.5`. If a stale RP branch appears again, use `skip_pr: true` once to cut the tag directly, then run again without inputs to get the snapshot PR.
