### PR TITLE
chore(release-please): set last-release-sha to v1.0.4

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
+  "last-release-sha": "23d1a22fbcbf7247e6e12adb6e3ede236f4ed785",
   "packages": {
     ".": {
       "release-type": "java",


### PR DESCRIPTION
Force release-please to treat v1.0.4 as the last release base so it opens a correct 1.0.5 Release PR (instead of jumping to a SNAPSHOT PR) after prior manual merges.

Change
- Add `last-release-sha: 23d1a22fbcbf7247e6e12adb6e3ede236f4ed785` to `release-please-config.json` (root).

Context
- main currently contains manual commits with subjects like `chore(release): release 1.0.5`, which release-please interprets as already-released and skips straight to SNAPSHOT PR creation.
- Setting `last-release-sha` pins the detection to the real tag `v1.0.4`, so a proper 1.0.5 Release PR is created.

Next steps after merge
1) Merge this PR to `dev`, then merge `dev` → `main`.
2) Run Actions → `release-please` with `release_as: 1.0.5` (no `-SNAPSHOT`).
3) Merge the Release PR → tag + GitHub Release is created.
4) release-please (java strategy) opens the `autorelease: snapshot` PR to bump `gradle.properties` to `1.0.6-SNAPSHOT`.

Cleanup
- After the chain is stable (release + snapshot PR merged), I’ll open a follow-up PR to remove `last-release-sha` so future releases auto-detect normally.
