### PR TITLE
chore(release-please): force-as v1.0.5 in config (one-off to cut tag)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
       "release-type": "java",
       "package-name": "edupy-debugger",
       "include-component-in-tag": false,
+      "release-as": "1.0.5",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
One-off force to cut v1.0.5 cleanly via manifest config, avoiding snapshot PRs created from earlier manual "chore(release)" commits on main.

Change
- Set package-level `release-as: "1.0.5"` in `release-please-config.json`.
- Keeps `last-release-sha` pinned to the real v1.0.4 tag.

Intended run sequence after merge
1) Merge this PR into `dev`, then merge `dev` → `main`.
2) Actions → release-please → Run workflow with `skip_pr: true` (and no inputs) OR with `release_as` empty; since config contains `release-as`, release-please will tag `v1.0.5` directly without a Release PR.
3) Trigger the workflow once more without inputs to let the Java strategy open the SNAPSHOT bump PR (to `1.0.6-SNAPSHOT`).

Cleanup
- After tag + snapshot PR are done, we will remove `release-as` and (optionally) `last-release-sha` so future releases follow the normal flow again.
