### PR TITLE
chore(version): set 1.0.5 for manual release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = de.code14.edupydebugger
 pluginName = EduPy-Debugger
 pluginRepositoryUrl = https://github.com/Julian-Code14/EduPy-Debugger
 # x-release-please-start-version
-version = 1.0.5-SNAPSHOT
+version = 1.0.5
 # x-release-please-end
 
 # SemVer format -> https://semver.org


### PR DESCRIPTION
One-off manual release prep: set the version in `gradle.properties` from `1.0.5-SNAPSHOT` to `1.0.5` inside the x-release-please marker block.

Why
- Release Please kept opening a `1.0.5-SNAPSHOT` PR due to past "release-like" commits on `main`. This PR stabilizes the state so we can cut v1.0.5 cleanly.

Next steps after merge
1) Merge this PR into `main`.
2) Immediately run Actions → `release-please` with inputs:
   - `release_as: 1.0.5`
   - `skip_pr: true`
   This creates tag `v1.0.5` + GitHub Release via the workflow (so the publish job runs).
3) Run the workflow once more without inputs to open the SNAPSHOT bump PR (`1.0.6-SNAPSHOT`).
4) Merge the SNAPSHOT PR and sync `main` → `dev`.

Follow-up
- I’ll open a small PR to remove `release-as` and (optionally) `last-release-sha` from `release-please-config.json` so future releases use the normal flow again.
