### PR TITLE
chore(release-please): align dev config with main (remove force keys)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,13 +2,11 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
-  "last-release-sha": "23d1a22fbcbf7247e6e12adb6e3ede236f4ed785",
   "packages": {
     ".": {
       "release-type": "java",
       "package-name": "edupy-debugger",
       "include-component-in-tag": false,
-      "release-as": "1.0.5",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
Remove one-off force options from `release-please-config.json` on `dev` to match `main` exactly.

Changes
- Drop `last-release-sha` and `release-as` keys (these were only for recovery).

Why
- A PR `dev → main` currently shows a diff because `dev` still has these keys while `main` does not. Aligning config makes branches content-identical.

After merge
- `dev → main` with no functional changes should show 0 changed files (clean).
