### PR TITLE
fix(ui): correct startup branding and status text

### DIFF
--- a/src/main/java/de/code14/edupydebugger/ui/DebuggerToolWindowFactory.java
+++ b/src/main/java/de/code14/edupydebugger/ui/DebuggerToolWindowFactory.java
@@ -84,7 +84,7 @@ public class DebuggerToolWindowFactory implements ToolWindowFactory {
         title.setFont(title.getFont().deriveFont(Font.BOLD, title.getFont().getSize2D() + 1f));
         loading.add(title, gbc);
         gbc.gridy = 1; gbc.insets = new Insets(0,8,8,8);
-        JLabel subtitle = new JLabel("Launching local servers and UI……");
+        JLabel subtitle = new JLabel("Launching local servers and UI…");
         loading.add(subtitle, gbc);
         gbc.gridy = 2; gbc.insets = new Insets(8,8,8,8);
         JLabel spinner = new JLabel(new AnimatedIcon.Default());

--- a/src/main/java/de/code14/edupydebugger/ui/DebuggerToolWindowFactory.java
+++ b/src/main/java/de/code14/edupydebugger/ui/DebuggerToolWindowFactory.java
@@ -80,11 +80,11 @@ public class DebuggerToolWindowFactory implements ToolWindowFactory {
         JPanel loading = new JPanel(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0; gbc.gridy = 0; gbc.insets = new Insets(8,8,4,8);
-        JLabel title = new JLabel("Starting EduPy Debugger…");
+        JLabel title = new JLabel("Starting EduPy-Debugger…");
         title.setFont(title.getFont().deriveFont(Font.BOLD, title.getFont().getSize2D() + 1f));
         loading.add(title, gbc);
         gbc.gridy = 1; gbc.insets = new Insets(0,8,8,8);
-        JLabel subtitle = new JLabel("Launching local servers and UI");
+        JLabel subtitle = new JLabel("Launching local servers and UI……");
         loading.add(subtitle, gbc);
         gbc.gridy = 2; gbc.insets = new Insets(8,8,8,8);
         JLabel spinner = new JLabel(new AnimatedIcon.Default());


### PR DESCRIPTION
Motivation
- Unifies product branding in the startup tool window ("EduPy‑Debugger").
- Clarifies the loading subtitle with a single, consistent ellipsis.

Key changes
- Adjusted two UI strings in `src/main/java/de/code14/edupydebugger/ui/DebuggerToolWindowFactory.java`.
- No functional behavior changes; user‑visible text only.

Tests & checks
- Builds unchanged; no logic modified.
- No new tests required for text changes.

Risks
- None expected. Pure UI copy changes.

Follow‑ups
- None.

Release‑Please effect
- This `fix:` commit is a releasable unit for Java; after merging this PR and then squashing `dev → main`, Release‑Please should open the `1.0.6` Release PR, followed by the automatic `1.0.7‑SNAPSHOT` bump PR after merge.