### PR TITLE
fix: prepare 1.0.7 release

### DIFF
--- a/.github/workflows/release-please-on-merge.yml
+++ b/.github/workflows/release-please-on-merge.yml
@@ -1,0 +1,79 @@
+name: release-please-on-merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  tag_and_snapshot:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tag GitHub release for merged Release PR
+        id: rp
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: main
+          skip-github-pull-request: true
+
+      - name: Open SNAPSHOT bump PR (java)
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: main
+
+      - name: Fetch Sources at release tag
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.rp.outputs.tag_name }}
+
+      - name: Setup Java
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Gradle
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Extract version (strip leading 'v')
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        id: v2
+        shell: bash
+        run: |
+          RAW="${{ steps.rp.outputs.tag_name }}"
+          VERSION="${RAW#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Publish Plugin to Marketplace
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+        run: |
+          ./gradlew \
+            -PpluginVersion="${{ steps.v2.outputs.version }}" \
+            publishPlugin --no-daemon --stacktrace
+
+      - name: Upload Release Asset (zip)
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.rp.outputs.tag_name }}" ./build/distributions/*

--- a/src/main/java/de/code14/edupydebugger/ui/DebuggerToolWindowFactory.java
+++ b/src/main/java/de/code14/edupydebugger/ui/DebuggerToolWindowFactory.java
@@ -168,7 +168,7 @@ public class DebuggerToolWindowFactory implements ToolWindowFactory {
                 SwingUtilities.invokeLater(() -> {
                     if (jbCefBrowser == null && JBCefApp.isSupported()) {
                         jbCefBrowser = new JBCefBrowser("http://127.0.0.1:8026/index.html");
-                        LOGGER.info("Loading JBCef browser...");
+                        LOGGER.info("Loading JBCef browser…");
                     } else if (jbCefBrowser != null) {
                         jbCefBrowser.loadURL("http://127.0.0.1:8026/index.html");
                         LOGGER.info("Reloaded JBCef browser");


### PR DESCRIPTION
Purpose
- Cut 1.0.7 from current state of dev to drive the Release Please flow.
- After merge to main, Release Please should open the 1.0.7 Release PR; after merging that, the Java strategy will open the 1.0.8‑SNAPSHOT bump PR.

Notes
- If PR #286 merges into `dev`, this PR will update automatically to include it.

Merging
- Please squash‑merge so the resulting commit on `main` retains the `fix:` prefix for Release Please.