### PR TITLE
ci(release-please): ensure tag-on-merge + explicit manifest

### DIFF
--- a/.github/workflows/release-please-on-merge.yml
+++ b/.github/workflows/release-please-on-merge.yml
@@ -21,12 +21,16 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: main
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
           skip-github-pull-request: true
 
       - name: Open SNAPSHOT bump PR (java)
         if: ${{ steps.rp.outputs.release_created == 'true' }}
         uses: googleapis/release-please-action@v4
         with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: main
 
@@ -64,7 +68,7 @@ jobs:
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
-          PRIVATE KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
         run: |
           ./gradlew \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,10 +29,11 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: rp
         with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: main
           release-as: ${{ inputs.release_as }}
-          skip-labeling: true
           skip-github-pull-request: ${{ inputs.skip_pr }}
   publish:
     needs: release


### PR DESCRIPTION
Problem
- Nach Merge des Release-PRs wurde kein Tag/Release erzeugt; stattdessen eröffnete der Push-Workflow einen neuen Release-PR.

Änderungen
- release-please.yml: explizit config-file und manifest-file gesetzt; (implizit entfällt skip-labeling damit Labels wieder gesetzt werden können).
- release-please-on-merge.yml: für Tagging und SNAPSHOT-Bump ebenfalls config-file/manifest-file ergänzt; ENV-Name PRIVATE_KEY korrigiert.

Erwartetes Verhalten
- Beim Schließen eines Release-PRs (Branch beginnt mit release-please--) wird direkt das GitHub-Release + Tag erstellt.
- Danach öffnet release-please automatisch den SNAPSHOT-Bump-PR.
- Der Push-Workflow (auf main) fungiert als Fallback und published beim gleichen Run, wenn release_created==true.

Risiken
- Keine Runtime-Änderungen am Plugin selbst. Nur CI.

Nach dem Merge
- dev -> main mergen; dann kleinen Fix committen und Flow erneut testen.