### PR TITLE
fix(build): clarify signing password is optional (release trigger)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,6 +134,8 @@ intellijPlatform {
     }
 
     signing {
+
+        // Note: PRIVATE_KEY_PASSWORD is optional for unencrypted keys; see CI secrets check.
         if (certChainEnv.orNull != null && privateKeyEnv.orNull != null) {
             // Variante: Secrets enthalten PEM-Inhalte → in Dateien schreiben
             certificateChainFile.set(signingCertFile)


### PR DESCRIPTION
Minimal, non-functional change to trigger a patch release via conventional commit.

- Clarify in `build.gradle.kts` that `PRIVATE_KEY_PASSWORD` is optional for unencrypted keys (comment only)

This is safe and intended to generate a `fix(...)` entry so Release Please will open the 1.0.8 release PR once merged to `main` (after regular `dev → main`).

No behavior change, build remains identical.
