### PR TITLE
ci(release-please): hotfix invalid if on main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,7 +47,7 @@ jobs:
 
   publish:
     needs: release
-    if: ${{ needs.release.outputs.release_created == \"true\" }}
+    if: ${{ needs.release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Hotfix: fix invalid expression in `release-please.yml` on main.

- Use correct condition syntax: `${{ needs.release.outputs.release_created == 'true' }}`
- No other changes.

This unblocks the workflow parser error and lets release‑please run again on main.