### PR TITLE
docs(readme): comply with Marketplace description requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # EduPy-Debugger
 
 <!-- Plugin description -->
+EduPy-Debugger is a lightweight, web-based Python debugging tool for PyCharm (Community and Professional). It focuses on teaching and onboarding, providing a clean variables view, visual object cards, and an integrated console.
+
 EduPy‑Debugger ist ein schlankes, webbasiertes Debug‑Werkzeug für Python in PyCharm (Community & Professional) – mit klarem Fokus auf Unterricht und Einstieg. Es kombiniert eine aufgeräumte Debug‑Ansicht mit visualisierten Objekten und einer integrierten Konsole.
 
 Kurzüberblick:
@@ -182,3 +184,4 @@ Integrationstests nutzen das IntelliJ‑Platform‑Testing‑Framework.
 
 EduPy‑Debugger steht unter der **MIT-Lizenz**.  
 Den vollständigen Text findest du in der Datei **LICENSE**.
+EduPy-Debugger is a lightweight, web-based Python debugging tool for PyCharm (Community and Professional). It focuses on teaching and onboarding, providing a clean variables view, visual object cards, and an integrated console.


### PR DESCRIPTION
Fix publish failure from JetBrains Marketplace validator (Invalid plugin descriptor 'description'). The README plugin description block now begins with a concise English paragraph (>40 chars, starts with ASCII letter) as required. No code changes.

- Source: README.md:3-12
- Affects: patchPluginXml pluginDescription extraction
- Tests: Build unchanged; publish step should pass description rule.

Risks: none (documentation only).